### PR TITLE
chore: upgrade tailscale to 1.96.4

### DIFF
--- a/btv/tailscale.scm
+++ b/btv/tailscale.scm
@@ -2,7 +2,6 @@
   #:use-module ((guix licenses) #:prefix license:)
   #:use-module (guix utils)
   #:use-module (guix gexp)
-  #:use-module (guix download)
   #:use-module (guix packages)
   #:use-module (guix build-system go)
   #:use-module (gnu packages golang)
@@ -15,18 +14,17 @@
   #:use-module (gnu)
   #:use-module (gnu services shepherd))
 
+(define go-package go-1.26)
+(define tailscale-version "1.96.4")
+(define tailscale-go-git-ref-hash "0qqlj6cq43h0pr8jg9g956yz5xgg81959vq2kl7n9yqnixyh8w2n")
+(define tailscale-go-fetch-vendor-hash "1lz2pmyfka0inhiasgfd1spxa5ikn56c76r3zg136n9dz6163wz2")
+
 (define-record-type* <go-git-reference>
   go-git-reference make-go-git-reference
   go-git-reference?
   (url    go-git-reference-url)
   (commit go-git-reference-commit)
   (sha    go-git-reference-sha256))
-
-(define-record-type* <go-url-reference>
-  go-url-reference make-go-url-reference
-  go-url-reference?
-  (url go-url-reference-url)
-  (sha go-url-reference-sha))
 
 (define* (go-fetch-vendored uri hash-algorithm hash-value name #:key system)
   (let ((src
@@ -37,11 +35,6 @@
               (uri (git-reference
                     (url url)
                     (commit commit)))
-              (sha256 sha)))
-           (($ <go-url-reference> url commit sha)
-            (origin
-              (method url-fetch)
-              (uri url)              
               (sha256 sha)))))
         (name (or name "go-git-checkout")))
     (gexp->derivation
@@ -50,7 +43,7 @@
        #~(begin
            (use-modules (guix build utils))
            (let ((inputs (list
-                          #+go-1.23
+                          #+go-package
                           #+tar
                           #+bzip2
                           #+gzip)))
@@ -79,11 +72,11 @@
                      (copy-file #$src name)
                      (when command
                        (invoke command "--decompress" name)))))))
-           
+
            (setenv "GOCACHE" "/tmp/gc")
            (setenv "GOMODCACHE" "/tmp/gmc")
-           (setenv "SSL_CERT_DIR" #+(file-append nss-certs "/etc/ssl/certs/"))        
-           
+           (setenv "SSL_CERT_DIR" #+(file-append nss-certs "/etc/ssl/certs/"))
+
            (invoke "go" "mod" "vendor")
 
            (invoke "tar" "czvf" #$output
@@ -97,61 +90,61 @@
      #:hash hash-value
      #:hash-algo hash-algorithm)))
 
+(define tailscale-source
+  (origin
+    (method go-fetch-vendored)
+    (uri (go-git-reference
+          (url "https://github.com/tailscale/tailscale")
+          (commit (string-append "v" tailscale-version))
+          (sha (base32 tailscale-go-git-ref-hash))))
+    (sha256
+     (base32 tailscale-go-fetch-vendor-hash))))
+
 (define-public tailscale
-  (let ((version "1.74.1"))
-    (package
-      (name "tailscale")
-      (version version)
-      (source (origin
-                (method go-fetch-vendored)
-                (uri (go-git-reference
-                      (url "https://github.com/tailscale/tailscale")
-                      (commit "v1.74.1")
-                      (sha (base32 "0ncck013rzbrzcbpya1fq41jrgzxw22pps77l9kb7kx06as8bggb"))))
-                (sha256
-                 (base32
-                  "19sv3q0hgb1h5v75c8hrkna4xgbgrs0ym2kvq16rbn9kr0hjjr1j"))))
-      (build-system go-build-system)
-      (arguments
-       `(#:import-path "tailscale.com/cmd/tailscale"
-         #:unpack-path "tailscale.com"
-         #:install-source? #f
-         #:phases
-         (modify-phases %standard-phases
-           (delete 'check))
-         #:go ,go-1.23))
-      (home-page "https://tailscale.com")
-      (synopsis "Tailscale client")
-      (description "Tailscale client")
-      (license license:bsd-3))))
+  (package
+    (name "tailscale")
+    (version tailscale-version)
+    (source tailscale-source)
+    (build-system go-build-system)
+    (arguments
+     `(#:import-path "tailscale.com/cmd/tailscale"
+       #:unpack-path "tailscale.com"
+       #:install-source? #f
+       #:phases
+       (modify-phases %standard-phases
+         (delete 'check))
+       #:go ,go-package))
+    (home-page "https://tailscale.com")
+    (synopsis "Tailscale client")
+    (description "Tailscale client")
+    (license license:bsd-3)))
 
 (define-public tailscaled
-  (let ((import-path "tailscale.com/cmd/tailscaled"))
-    (package
-      (inherit tailscale)
-      (name "tailscaled")
-      (arguments
-       (substitute-keyword-arguments (package-arguments tailscale)
-         ((#:import-path _ #f)
-          import-path)
-         ((#:phases phases #~%standard-phases)
-          #~(modify-phases #$phases
-              (replace 'build
-                (lambda _
-                  ;; idk why but we have to unset GO111MODULE in order for the build to work
-                  ;; [btv] maybe vendor stuff is not getting picked up in go path?
-                  (unsetenv "GO111MODULE")
-                  (chdir "./src/tailscale.com")
-                  (invoke "go" "build" "-o" "tailscaled"
-                          #$import-path)
-                  (chdir "../..")))
-              (replace 'install
-                (lambda _
-                  (install-file "src/tailscale.com/tailscaled" (string-append #$output "/bin"))))))))
-      (synopsis "Tailscale daemon")
-      (description "Tailscale daemon"))))
+  (package
+    (inherit tailscale)
+    (name "tailscaled")
+    (arguments
+     (substitute-keyword-arguments (package-arguments tailscale)
+       ((#:import-path _ #f)
+        "tailscale.com/cmd/tailscaled")
+       ((#:phases phases #~%standard-phases)
+        #~(modify-phases #$phases
+            (replace 'build
+              (lambda _
+                (chdir "./src/tailscale.com")
+                (invoke "go" "build" "-o" "tailscaled"
+                        "tailscale.com/cmd/tailscaled")
+                (chdir "../..")))
+            (replace 'install
+              (lambda _
+                (install-file "src/tailscale.com/tailscaled"
+                              (string-append #$output "/bin"))))))))
+    (synopsis "Tailscale daemon")
+    (description "Tailscale daemon")))
 
-(define-public (tailscale-configuration) '())
+(define-record-type* <tailscale-configuration>
+  tailscale-configuration make-tailscale-configuration
+  tailscale-configuration?)
 
 (define (tailscale-shepherd-service config)
   (list (shepherd-service


### PR DESCRIPTION
Upgrade to latest tailscale + refactor.

- Make it easier to upgrade via top-file variables.
- Add a proper tailscale-configuration record-type should fields be needed in the future.
- Fixed unwanted extra spaces